### PR TITLE
Autotracking for items and keys in doors

### DIFF
--- a/colors.html
+++ b/colors.html
@@ -1,17 +1,17 @@
 <html>
 	<head>
 		<title>ALTTP Randomizer Community Tracker - Color Settings</title>
-		<script type="text/javascript" src="js/index.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-		<script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-		<script type="text/javascript" src="js/colors.js?v=20250204" defer></script>
-		<link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-		<link href="css/launcher.css?v=20250204" rel="stylesheet">
-		<link href="css/fonts.css?v=20250204" rel="stylesheet">
-		<link href="css/sprites.css?v=20250204" rel="stylesheet">
-		<link href="css/toast.css?v=20250204" rel="stylesheet">
-		<link href="css/style.css?v=20250204" rel="stylesheet">
+		<script type="text/javascript" src="js/index.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+		<script type="text/javascript" src="js/colors.js?v=20250302" defer></script>
+		<link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+		<link href="css/launcher.css?v=20250302" rel="stylesheet">
+		<link href="css/fonts.css?v=20250302" rel="stylesheet">
+		<link href="css/sprites.css?v=20250302" rel="stylesheet">
+		<link href="css/toast.css?v=20250302" rel="stylesheet">
+		<link href="css/style.css?v=20250302" rel="stylesheet">
 		<style>
 			a { color: red; }
 		</style>

--- a/contributors.html
+++ b/contributors.html
@@ -1,15 +1,15 @@
 <html>
 	<head>
 		<title>ALTTP Randomizer Community Tracker - Contributors</title>
-		<script type="text/javascript" src="js/index.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-		<script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-		<link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-		<link href="css/launcher.css?v=20250204" rel="stylesheet">
-		<link href="css/fonts.css?v=20250204" rel="stylesheet">
-		<link href="css/sprites.css?v=20250204" rel="stylesheet">
-		<link href="css/toast.css?v=20250204" rel="stylesheet">
+		<script type="text/javascript" src="js/index.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+		<link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+		<link href="css/launcher.css?v=20250302" rel="stylesheet">
+		<link href="css/fonts.css?v=20250302" rel="stylesheet">
+		<link href="css/sprites.css?v=20250302" rel="stylesheet">
+		<link href="css/toast.css?v=20250302" rel="stylesheet">
 		<style>
 			a { color: red; }
 		</style>

--- a/downloads.html
+++ b/downloads.html
@@ -1,15 +1,15 @@
 <html>
 	<head>
 		<title>ALTTP Randomizer Community Tracker - Downloads</title>
-		<script type="text/javascript" src="js/index.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-		<script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-		<link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-		<link href="css/launcher.css?v=20250204" rel="stylesheet">
-		<link href="css/fonts.css?v=20250204" rel="stylesheet">
-		<link href="css/sprites.css?v=20250204" rel="stylesheet">
-		<link href="css/toast.css?v=20250204" rel="stylesheet">
+		<script type="text/javascript" src="js/index.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+		<link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+		<link href="css/launcher.css?v=20250302" rel="stylesheet">
+		<link href="css/fonts.css?v=20250302" rel="stylesheet">
+		<link href="css/sprites.css?v=20250302" rel="stylesheet">
+		<link href="css/toast.css?v=20250302" rel="stylesheet">
 		<style>
 			a { color: red; }
 		</style>

--- a/dungeontracker.html
+++ b/dungeontracker.html
@@ -2,14 +2,14 @@
 <html>
    <head>
       <title>ALTTP Randomizer Community Tracker - Dungeon Tracker</title>
-      <script src="js/jquery-3.3.1.js?v=20250204"></script>
-      <script src="js/bootstrap.min.js?v=20250204"></script>
-      <link rel="stylesheet" type="text/css" href="css/dungeonstyle.css?v=20250204">
-      <link rel="stylesheet" type="text/css" href="css/sprites.css?v=20250204">
-      <link rel="stylesheet" type="text/css" href="css/fonts.css?v=20250204" >
-      <script src="js/util.js?v=20250204"></script>
-      <script src="js/owdungeondata.js?v=20250204"></script>
-      <script src="js/dungeontracker.js?v=20250204"></script>
+      <script src="js/jquery-3.3.1.js?v=20250302"></script>
+      <script src="js/bootstrap.min.js?v=20250302"></script>
+      <link rel="stylesheet" type="text/css" href="css/dungeonstyle.css?v=20250302">
+      <link rel="stylesheet" type="text/css" href="css/sprites.css?v=20250302">
+      <link rel="stylesheet" type="text/css" href="css/fonts.css?v=20250302" >
+      <script src="js/util.js?v=20250302"></script>
+      <script src="js/owdungeondata.js?v=20250302"></script>
+      <script src="js/dungeontracker.js?v=20250302"></script>
       <meta charset="UTF-8">
       <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
       <meta http-equiv="Pragma" content="no-cache" />

--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@
                   </span>
                   <span class="preset-span">
                      <input id="doorpots" value="P" type="radio" name="doorgroup" />
-                     <label for="doorpots">Pots</label>
+                     <label for="doorpots">Keydrop</label>
                   </span>
                </div>
                <div>

--- a/index.html
+++ b/index.html
@@ -2,16 +2,16 @@
 
 <head>
    <title>ALTTP Randomizer Community Tracker - Launcher</title>
-   <script type="text/javascript" src="js/index.js?v=20250204"></script>
-   <script type="text/javascript" src="js/autot.js?v=20250204"></script>
-   <script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-   <script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-   <script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-   <link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-   <link href="css/launcher.css?v=20250204" rel="stylesheet">
-   <link href="css/fonts.css?v=20250204" rel="stylesheet">
-   <link href="css/sprites.css?v=20250204" rel="stylesheet">
-   <link href="css/toast.css?v=20250204" rel="stylesheet">
+   <script type="text/javascript" src="js/index.js?v=20250302"></script>
+   <script type="text/javascript" src="js/autot.js?v=20250302"></script>
+   <script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+   <script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+   <script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+   <link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+   <link href="css/launcher.css?v=20250302" rel="stylesheet">
+   <link href="css/fonts.css?v=20250302" rel="stylesheet">
+   <link href="css/sprites.css?v=20250302" rel="stylesheet">
+   <link href="css/toast.css?v=20250302" rel="stylesheet">
    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
    <meta http-equiv="Pragma" content="no-cache" />
    <meta http-equiv="Expires" content="0" />

--- a/instructions.html
+++ b/instructions.html
@@ -1,15 +1,15 @@
 <html>
 	<head>
 		<title>ALTTP Randomizer Community Tracker - Instructions</title>
-		<script type="text/javascript" src="js/index.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-		<script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-		<link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-		<link href="css/launcher.css?v=20250204" rel="stylesheet">
-		<link href="css/fonts.css?v=20250204" rel="stylesheet">
-		<link href="css/sprites.css?v=20250204" rel="stylesheet">
-		<link href="css/toast.css?v=20250204" rel="stylesheet">
+		<script type="text/javascript" src="js/index.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+		<link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+		<link href="css/launcher.css?v=20250302" rel="stylesheet">
+		<link href="css/fonts.css?v=20250302" rel="stylesheet">
+		<link href="css/sprites.css?v=20250302" rel="stylesheet">
+		<link href="css/toast.css?v=20250302" rel="stylesheet">
 		<script>
 			$(function() {
 				$('.south').powerTip({ placement: 's' });

--- a/issues.html
+++ b/issues.html
@@ -1,15 +1,15 @@
 <html>
 	<head>
 		<title>ALTTP Randomizer Community Tracker - Known Issues</title>
-		<script type="text/javascript" src="js/index.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-		<script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-		<link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-		<link href="css/launcher.css?v=20250204" rel="stylesheet">
-		<link href="css/fonts.css?v=20250204" rel="stylesheet">
-		<link href="css/sprites.css?v=20250204" rel="stylesheet">
-		<link href="css/toast.css?v=20250204" rel="stylesheet">
+		<script type="text/javascript" src="js/index.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+		<link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+		<link href="css/launcher.css?v=20250302" rel="stylesheet">
+		<link href="css/fonts.css?v=20250302" rel="stylesheet">
+		<link href="css/sprites.css?v=20250302" rel="stylesheet">
+		<link href="css/toast.css?v=20250302" rel="stylesheet">
 		<style>
 			a { color: red; }
 		</style>

--- a/js/autot.js
+++ b/js/autot.js
@@ -592,11 +592,11 @@ function autotrackReadMem() {
     }
 
     function addPseudobootsFlag() {
-        // Check if we're playing DR and that the mystery flag is not set
+        // Check if we're playing DR and that the mystery flag is not set, move on to item and key counts if DR
         if (["DR", "OR"].includes(data['fork']) && (data['mystery'][1] & 0x1) === 0) {
             snesreadsave(PSEUDOBOOTS_LOC, 0x1, data, 'pseudoboots', addCompassCountSeenData);
         } else {
-            addCompassCountSeenData();
+            handleAutoTrackData();
         }
     }
 
@@ -712,20 +712,6 @@ function autotrackDoTracking(data) {
 
     // Autotrack dungeon key and chest counts if count has been seen by entering the dungeon (for keys, when map in inventory, for checks basically always since that setting is generally on)
     if (flags.doorshuffle === 'C' && flags.autotracking === 'Y' && data["fork"] !== "VT") {
-        // var dungeon_item_count_seen = (_location_data[0x403] << 8) + _location_data[0x404]
-        //var dungeon_key_count_seen = (_location_data[0x474] << 8) + _location_data[0x475]
-        //var big_key_field = (_location_data[0x366] << 8) + _location_data[0x367]
-        //for dun in dungeon_masks:
-        //    var mask_data = dungeon_masks[dun]
-        //    notes_window.find_node(dun).set_current_checks(_location_data[0x4B0 + mask_data[1]] + ((_location_data[0x4B0 + mask_data[1] - 1]) << 8))
-        //    notes_window.find_node(dun).set_current_keys(_location_data[0x4E0 + (mask_data[1]/2)])
-        //    if dungeon_item_count_seen & mask_data[0]:
-        //        notes_window.find_node(dun).set_total_checks(_location_data[0x500 + mask_data[1]] + ((_location_data[0x500 + mask_data[1] - 1]) << 8))
-        //    if dungeon_key_count_seen & mask_data[0]:
-        //        notes_window.find_node(dun).set_total_keys(_location_data[0x520 + (mask_data[1]/2)])
-
-
-
         var dungeon_masks = {
             11: [0x00C0, 2],
             0: [0x0020, 4],

--- a/js/autot.js
+++ b/js/autot.js
@@ -23,6 +23,12 @@ var DRFLAGS_LOC = 0x138004; // Actually DRFlags
 var PRIZES_LOC = 0x1209B; // Pendant/Crystal number data
 var PRIZES2_LOC = 0x180050; // Pendant/Crystal data
 var KEYSANITY_LOC = 0x18016A; // Keysanity flags
+var COMPASSCOUNTSEEN_LOC = SAVEDATA_START + 0x403; //Compass count seen flags, for autotracking chest counts in doors
+var MAPCOUNTSEEN_LOC = SAVEDATA_START + 0x474; //Map count seen flags, for autotracking key counts in doors
+var COMPASSCOUNT_LOC = 0xF65410; //Max item counts for each dungeon
+var MAPCOUNT_LOC = 0xF65430; //Max key counts for each dungeon
+var CHECKS_LOC = SAVEDATA_START + 0x4B0; //Current checks in each dungeon
+var KEYS_LOC = SAVEDATA_START + 0x4E0; //Current keys in each dungeon
 
 var CONFIGURING = false;
 
@@ -588,10 +594,34 @@ function autotrackReadMem() {
     function addPseudobootsFlag() {
         // Check if we're playing DR and that the mystery flag is not set
         if (["DR", "OR"].includes(data['fork']) && (data['mystery'][1] & 0x1) === 0) {
-            snesreadsave(PSEUDOBOOTS_LOC, 0x1, data, 'pseudoboots', handleAutoTrackData);
+            snesreadsave(PSEUDOBOOTS_LOC, 0x1, data, 'pseudoboots', addCompassCountSeenData);
         } else {
-            handleAutoTrackData();
+            addCompassCountSeenData();
         }
+    }
+
+    function addCompassCountSeenData() {
+        snesreadsave(COMPASSCOUNTSEEN_LOC, 0x2, data, 'compasscountseen', addMapCountSeenData);
+    }
+
+    function addMapCountSeenData() {
+        snesreadsave(MAPCOUNTSEEN_LOC, 0x2, data, 'mapcountseen', addCompassCount);
+    }
+
+    function addCompassCount() {
+        snesreadsave(COMPASSCOUNT_LOC, 0x20, data, 'compasscount', addMapCount);
+    }
+
+    function addMapCount() {
+        snesreadsave(MAPCOUNT_LOC, 0x10, data, 'mapcount', addDungeonChecks);
+    }
+
+    function addDungeonChecks() {
+        snesreadsave(CHECKS_LOC, 0x20, data, "dungeonchecks", addDungeonKeys);
+    }
+
+    function addDungeonKeys() {
+        snesreadsave(KEYS_LOC, 0x10, data, "dungeonkeys", handleAutoTrackData);
     }
 
     function handleAutoTrackData() {
@@ -678,6 +708,61 @@ function autotrackDoTracking(data) {
                 }
             }
         });
+    }
+
+    // Autotrack dungeon key and chest counts if count has been seen by entering the dungeon (for keys, when map in inventory, for checks basically always since that setting is generally on)
+    if (flags.doorshuffle === 'C' && flags.autotracking === 'Y' && data["fork"] !== "VT") {
+        // var dungeon_item_count_seen = (_location_data[0x403] << 8) + _location_data[0x404]
+        //var dungeon_key_count_seen = (_location_data[0x474] << 8) + _location_data[0x475]
+        //var big_key_field = (_location_data[0x366] << 8) + _location_data[0x367]
+        //for dun in dungeon_masks:
+        //    var mask_data = dungeon_masks[dun]
+        //    notes_window.find_node(dun).set_current_checks(_location_data[0x4B0 + mask_data[1]] + ((_location_data[0x4B0 + mask_data[1] - 1]) << 8))
+        //    notes_window.find_node(dun).set_current_keys(_location_data[0x4E0 + (mask_data[1]/2)])
+        //    if dungeon_item_count_seen & mask_data[0]:
+        //        notes_window.find_node(dun).set_total_checks(_location_data[0x500 + mask_data[1]] + ((_location_data[0x500 + mask_data[1] - 1]) << 8))
+        //    if dungeon_key_count_seen & mask_data[0]:
+        //        notes_window.find_node(dun).set_total_keys(_location_data[0x520 + (mask_data[1]/2)])
+
+
+
+        var dungeon_masks = {
+            11: [0x00C0, 2],
+            0: [0x0020, 4],
+            1: [0x0010, 6],
+            2: [0x2000, 20],
+            12: [0x0008, 8],
+            3: [0x0002, 12],
+            4: [0x0004, 10],
+            5: [0x8000, 16],
+            6: [0x1000, 22],
+            7: [0x4000, 18],
+            8: [0x0001, 14],
+            9: [0x0800, 24],
+            10: [0x0400, 26],
+        };
+
+        var dungeon_item_count_seen = (data["compasscountseen"][0] << 8) + data["compasscountseen"][1];
+        var dungeon_key_count_seen = (data["mapcountseen"][0] << 8) + data["mapcountseen"][1];
+        
+        for (let dun = 0; dun < 13; dun++) {
+            var mask_data = dungeon_masks[dun];
+            if (dungeon_item_count_seen & mask_data[0]){
+                var maxChecks = data["compasscount"][mask_data[1]]+ (data["compasscount"][mask_data[1] - 1] << 8);
+                var currentChecks = data["dungeonchecks"][mask_data[1]]
+                if (maxChecks - currentChecks - items['chestmanual'+ dun] < 0){
+                    items['chestmanual'+ dun] = maxChecks - currentChecks;
+                }
+                setChestCount(maxChecks - currentChecks, 'chest' + dun);
+            }
+            
+            if (dungeon_key_count_seen & mask_data[0]){
+                setKeyCount(data["dungeonkeys"][mask_data[1]/2], data["mapcount"][mask_data[1]/2], 'smallkey' + dun);
+            } else {
+                setKeyCount(data["dungeonkeys"][mask_data[1]/2], 99, 'smallkey' + dun);
+            }
+
+        };
     }
 
     dungeonPrizes = {}
@@ -971,7 +1056,7 @@ function autotrackDoTracking(data) {
     update_boss("agahnim2", 0x01B); // Ganons Tower
 
     function updatesmallkeys(dungeon, offset) {
-        if (changed(offset)) {
+        if (changed(offset) && flags.doorshuffle !== 'C') {
             var label = "smallkey" + dungeon;
             var newkeys = autotrackPrevData === null ? data['rooms_inv'][offset] : (data['rooms_inv'][offset] - autotrackPrevData['rooms_inv'][offset] + items[label]);
             if (newkeys > items[label]) {

--- a/js/items.js
+++ b/js/items.js
@@ -58,7 +58,7 @@
         var count = dungeonInfo.default;
         var keys = dungeonInfo.keys;
         if (flags.doorshuffle === 'C') {
-            count = 32;
+            count = 100;
             keys = 29;
         } else {
             if (flags.doorshuffle === 'P') {
@@ -176,6 +176,9 @@
         items['chestknown' + i] = false;
         items['bigkey' + i] = !(flags.wildbigkeys || flags.showbigkeys);
         items['smallkey' + i] = ((flags.wildkeys || flags.showsmallkeys) ? 0 : keyCounts[i]);
+        items['chestmanual' + i] = 0
+        items['keymanual' + i] = 0
+        items['maxkey' + i] = 99
     };
 
     if (flags.doorshuffle !== 'C') {

--- a/js/track.js
+++ b/js/track.js
@@ -169,6 +169,14 @@
 
 		// If left clicked on chest
 		if (label.substring(0,5) === 'chest') {
+			//do this when autotracking doors
+			if (flags.autotracking === 'Y' && flags.doorshuffle === 'C') {
+				if (document.getElementById(label).innerHTML > 0){
+					items['chestmanual'+label.substring(5)]++;
+				}
+				setChestCount(Number(document.getElementById(label).innerHTML) + Number(items['chestmanual'+label.substring(5)]) - 1, label);
+				return;
+			}
             var value = items.dec(label);
 			if (value === 0) {
 				if (!flags.wildkeys && !flags.wildbigkeys && flags.gametype != 'R' && flags.doorshuffle != 'C' && label.length === 6 && !flags.showsmallkeys && !flags.showbigkeys) {
@@ -225,6 +233,13 @@
 		}
 		
 		if (label.substring(0,12) === 'smallkeyhalf' || label.substring(0,8) === 'smallkey') {
+			//do this if autotracking doors
+			if (flags.autotracking === 'Y' && flags.doorshuffle === 'C') {
+					items['keymanual'+label.substring(8)]++;
+				setKeyCount(Number(document.getElementById(label).innerHTML) - Number(items['keymanual'+label.substring(8)]) + 1, items['maxkey'+label.substring(8)], label);
+				return;
+			}
+
 			if (flags.gametype != 'R') {
 				var value = items.inc(label);
 			} else {
@@ -584,6 +599,13 @@
     };
 	
 	window.rightClickChest = function(label) {
+		//do this when autotracking doors
+		if (flags.autotracking === 'Y' && flags.doorshuffle === 'C') {
+			items['chestmanual'+label.substring(5)] = Math.max(items['chestmanual'+label.substring(5)] - 1, 0);
+			setChestCount(Number(document.getElementById(label).innerHTML) + Number(items['chestmanual'+label.substring(5)]) + 1, label);
+			return;
+		}
+		
 		var value = items.inc(label);
 
 		let className = 'chest'
@@ -609,8 +631,39 @@
 
 		updateMapTracker();
 	};
+
+	
+	window.setChestCount = function(value, dungeon) {
+		value = value - items['chestmanual'+dungeon.substring(5)];
+		if (value <= 0) {
+			document.getElementById(dungeon).className = 'chest-0';
+			document.getElementById(dungeon).innerHTML = '';
+		} else {
+			document.getElementById(dungeon).className = 'chest';
+			document.getElementById(dungeon).innerHTML = value;
+		}
+	}
+
+	window.setKeyCount = function(value, maxKeys, dungeon) {		
+		
+		item['maxkey'+dungeon.substring(8)] = maxKeys;
+		if (maxKeys - value - items['keymanual'+dungeon.substring(8)] < 0){
+			items['keymanual'+ dungeon.substring(8)] = maxKeys - value;
+		}
+		value = value + items['keymanual'+dungeon.substring(8)];
+		document.getElementById(dungeon).innerHTML = value;
+		document.getElementById(dungeon).style.color = (value >= maxKeys) ? "green" : "white";
+		
+	}
 	
 	window.rightClickKey = function(label) {
+		//do this if autotracking doors
+		if (flags.autotracking === 'Y' && flags.doorshuffle === 'C') {
+			items['keymanual'+label.substring(8)] = Math.max(items['keymanual'+label.substring(8)] - 1, 0);
+			setKeyCount(Number(document.getElementById(label).innerHTML) - Number(items['keymanual'+label.substring(8)]) - 1, items['maxkey'+label.substring(8)], label);
+			return;
+		}
+
 		if (label.substring(0,12) === 'smallkeyhalf' || label.substring(0,8) === 'smallkey') {
 			if (flags.gametype != 'R') {
 				var value = items.dec(label);
@@ -622,7 +675,7 @@
 		}		
 		updateMapTracker();
 	};
-	
+
 	window.clickCompass = function(dungeonid) {
 		items['chestknown'+dungeonid] = !items['chestknown'+dungeonid];
 		document.getElementById('chest'+dungeonid).innerHTML = items['chest'+dungeonid] == 0 ? '' : (flags.doorshuffle === 'C' && !items['chestknown'+dungeonid] ? (items['chest'+dungeonid] - 1) + '+' : items['chest'+dungeonid]);

--- a/js/util.js
+++ b/js/util.js
@@ -1,7 +1,7 @@
 (function (window) {
 	'use strict';
 
-	window.buildString = "20250204";
+	window.buildString = "20250302";
 
 	// based on https://github.com/medialize/URI.js/blob/gh-pages/src/URI.js
 	window.uri_query = memoize(function () {

--- a/logic.html
+++ b/logic.html
@@ -1,18 +1,18 @@
 <html>
 	<head>
 		<title>ALTTP Randomizer Community Tracker - Logic Settings</title>
-		<script type="text/javascript" src="js/index.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-		<script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-		<script type="text/javascript" src="js/logicsettings.js?v=20250204" defer></script>
-		<link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-		<link href="css/launcher.css?v=20250204" rel="stylesheet">
-		<link href="css/fonts.css?v=20250204" rel="stylesheet">
-		<link href="css/sprites.css?v=20250204" rel="stylesheet">
-		<link href="css/toast.css?v=20250204" rel="stylesheet">
-		<link href="css/style.css?v=20250204" rel="stylesheet">
-		<link href="css/logicsettings.css?v=20250204" rel="stylesheet">
+		<script type="text/javascript" src="js/index.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+		<script type="text/javascript" src="js/logicsettings.js?v=20250302" defer></script>
+		<link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+		<link href="css/launcher.css?v=20250302" rel="stylesheet">
+		<link href="css/fonts.css?v=20250302" rel="stylesheet">
+		<link href="css/sprites.css?v=20250302" rel="stylesheet">
+		<link href="css/toast.css?v=20250302" rel="stylesheet">
+		<link href="css/style.css?v=20250302" rel="stylesheet">
+		<link href="css/logicsettings.css?v=20250302" rel="stylesheet">
 		<style>
 			a { color: red; }
 		</style>

--- a/release.html
+++ b/release.html
@@ -1,15 +1,15 @@
 <html>
 	<head>
 		<title>ALTTP Randomizer Community Tracker - Release Notes</title>
-		<script type="text/javascript" src="js/index.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250204"></script>
-		<script type="text/javascript" src="js/jquery.powertip.js?v=20250204"></script>
-		<script type="text/javascript" src="js/bootstrap.min.js?v=20250204"></script>
-		<link href="css/jquery.powertip.css?v=20250204" rel="stylesheet" />
-		<link href="css/launcher.css?v=20250204" rel="stylesheet">
-		<link href="css/fonts.css?v=20250204" rel="stylesheet">
-		<link href="css/sprites.css?v=20250204" rel="stylesheet">
-		<link href="css/toast.css?v=20250204" rel="stylesheet">
+		<script type="text/javascript" src="js/index.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery-3.3.1.js?v=20250302"></script>
+		<script type="text/javascript" src="js/jquery.powertip.js?v=20250302"></script>
+		<script type="text/javascript" src="js/bootstrap.min.js?v=20250302"></script>
+		<link href="css/jquery.powertip.css?v=20250302" rel="stylesheet" />
+		<link href="css/launcher.css?v=20250302" rel="stylesheet">
+		<link href="css/fonts.css?v=20250302" rel="stylesheet">
+		<link href="css/sprites.css?v=20250302" rel="stylesheet">
+		<link href="css/toast.css?v=20250302" rel="stylesheet">
 		<style>
 			a { color: lightblue; }
 		</style>

--- a/tracker.html
+++ b/tracker.html
@@ -2,37 +2,37 @@
 
 <head>
 	<title>ALTTP Randomizer Community Tracker - Tracker</title>
-	<script src="js/jquery-3.7.1.min.js?v=20250204"></script>
-	<script src="js/bootstrap.min.js?v=20250204"></script>
-	<link rel="stylesheet" type="text/css" href="css/sprites.css?v=20250204">
-	<link rel="stylesheet" type="text/css" href="css/fonts.css?v=20250204">
-	<link rel="stylesheet" type="text/css" href="css/colors.css?v=20250204">
+	<script src="js/jquery-3.7.1.min.js?v=20250302"></script>
+	<script src="js/bootstrap.min.js?v=20250302"></script>
+	<link rel="stylesheet" type="text/css" href="css/sprites.css?v=20250302">
+	<link rel="stylesheet" type="text/css" href="css/fonts.css?v=20250302">
+	<link rel="stylesheet" type="text/css" href="css/colors.css?v=20250302">
 	<link rel="stylesheet" type="text/css" id="mainstyle">
 	<link rel="stylesheet" type="text/css" id="maincompactstyle">
-	<script src="js/util.js?v=20250204"></script>
-	<script src="js/logicsettings.js?v=20250204"></script>
+	<script src="js/util.js?v=20250302"></script>
+	<script src="js/logicsettings.js?v=20250302"></script>
 
-	<script src="data/entrance_to_array_id.js?v=20250204"></script>
-	<script src="data/entrances_data.js?v=20250204"></script>
-	<script src="data/chests_data.js?v=20250204"></script>
-	<script src="data/data_objects.js?v=20250204"></script>
-	<script src="data/logic/logic_dungeon_keydrop.js?v=20250204"></script>
-	<script src="data/logic/logic_dungeon.js?v=20250204"></script>
-	<script src="data/logic/logic_entrances.js?v=20250204"></script>
-	<script src="data/logic/logic_nondungeon_checks_entrance.js?v=20250204"></script>
-	<script src="data/logic/logic_nondungeon_checks.js?v=20250204"></script>
-	<script src="data/logic/logic_regions.js?v=20250204"></script>
+	<script src="data/entrance_to_array_id.js?v=20250302"></script>
+	<script src="data/entrances_data.js?v=20250302"></script>
+	<script src="data/chests_data.js?v=20250302"></script>
+	<script src="data/data_objects.js?v=20250302"></script>
+	<script src="data/logic/logic_dungeon_keydrop.js?v=20250302"></script>
+	<script src="data/logic/logic_dungeon.js?v=20250302"></script>
+	<script src="data/logic/logic_entrances.js?v=20250302"></script>
+	<script src="data/logic/logic_nondungeon_checks_entrance.js?v=20250302"></script>
+	<script src="data/logic/logic_nondungeon_checks.js?v=20250302"></script>
+	<script src="data/logic/logic_regions.js?v=20250302"></script>
 
-	<script src="data/logic/owg/logic_entrances.js?v=20250204"></script>
-	<script src="data/logic/owg/logic_nondungeon_checks_entrance.js?v=20250204"></script>
-	<script src="data/logic/owg/logic_nondungeon_checks.js?v=20250204"></script>
-	<script src="data/logic/owg/logic_regions.js?v=20250204"></script>
+	<script src="data/logic/owg/logic_entrances.js?v=20250302"></script>
+	<script src="data/logic/owg/logic_nondungeon_checks_entrance.js?v=20250302"></script>
+	<script src="data/logic/owg/logic_nondungeon_checks.js?v=20250302"></script>
+	<script src="data/logic/owg/logic_regions.js?v=20250302"></script>
 
-	<script src="js/items.js?v=20250204"></script>
-	<script src="js/chests.js?v=20250204"></script>
-	<script src="js/track.js?v=20250204"></script>
-	<script src="js/spoiler.js?v=20250204"></script>
-	<script src="js/autot.js?v=20250204"></script>
+	<script src="js/items.js?v=20250302"></script>
+	<script src="js/chests.js?v=20250302"></script>
+	<script src="js/track.js?v=20250302"></script>
+	<script src="js/spoiler.js?v=20250302"></script>
+	<script src="js/autot.js?v=20250302"></script>
 	<script>
 		var colorSettings = JSON.parse(localStorage.getItem('colorSettings'));
 		for (var key in colorSettings) {


### PR DESCRIPTION
- Added autotracking for items and keys in doors. 
  - Item counts won't update until the in game item counter has been seen in the dungeon by bringing the compass or having the setting enabled (generally doors modes have this enabled by default)
  - Key counts are autotracked, once the max key count has been seen by bringing the map to the dungeon the key count will turn green once it is reached
- Renamed "Pots" to "Keydrop" in the inital settings