### PR TITLE
misc logic fixes

### DIFF
--- a/data/logic/logic_nondungeon_checks.js
+++ b/data/logic/logic_nondungeon_checks.js
@@ -6335,6 +6335,28 @@
                     "speed" // not putting stupid blue suits in logic because they're stupid
                 ]
             },
+            "scout": {
+                "allOf": [
+                    "canBreach|Maridia - Main Street",
+                    {
+                        "anyOf": [
+                            "gravity",
+                            {
+                                "allOf": [
+                                    "canSuitlessMaridia",
+                                    "hijump",
+                                    {
+                                        "anyOf": [
+                                            "canHijumpIceMainStreetClimb",
+                                            "canSpringBallJump"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
             "logical": {
                 "allOf": [
                     "canReach|Maridia - Main Street",

--- a/data/logic/logic_nondungeon_checks.js
+++ b/data/logic/logic_nondungeon_checks.js
@@ -5770,6 +5770,7 @@
             "scout": {
                 "allOf": [
                     "canBreach|Brinstar - Blue",
+                    "SMKeys|Brinstar1"
                 ]
             },
             "logical": {
@@ -6590,7 +6591,17 @@
         "Open": {
             "always": {
                 "allOf": [
-                    "canBreach|Maridia - Pre-Aqueduct",
+                    {
+                        "anyOf": [
+                            "canBreach|Maridia - Pre-Aqueduct",
+                            {
+                                "allOf": [
+                                    "canBreach|Maridia - Portal",
+                                    "SMKeys|Maridia2"
+                                ]
+                            }
+                        ]
+                    },
                     "gravity",
                     {
                         "anyOf": [
@@ -6602,19 +6613,59 @@
             },
             "scout": {
                 "allOf": [
-                    "canBreach|Maridia - Pre-Aqueduct",
                     {
                         "anyOf": [
-                            "gravity",
-                            "canGrappleJump",
-                            "canSnailClimb"
+                            {
+                                "allOf": [
+                                    "canBreach|Maridia - Pre-Aqueduct",
+                                    {
+                                        "anyOf": [
+                                            "gravity",
+                                            "canGrappleJump",
+                                            "canSnailClimb"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "allOf": [
+                                    "canBreach|Maridia - Portal",
+                                    "SMKeys|Maridia2",
+                                    {
+                                        "anyOf": [ // can traverse post-botwoon right to
+                                            "gravity",
+                                            "hijump",
+                                            "ice",
+                                            "canSpringBallJump"
+                                        ]
+                                    },
+                                    {
+                                        "anyOf": [
+                                            "gravity",
+                                            "canGrappleJump",
+                                            "canSnailClimb"
+                                        ]
+                                    }
+                                ]
+                            }
                         ]
-                    }
+                    },
+                    
                 ]
             },
             "logical": {
                 "allOf": [
-                    "canReach|Maridia - Pre-Aqueduct",
+                    {
+                        "anyOf": [
+                            "canReach|Maridia - Pre-Aqueduct",
+                            {
+                                "allOf": [
+                                    "canReach|Maridia - Portal",
+                                    "SMKeys|Maridia2"
+                                ]
+                            }
+                        ]
+                    },
                     "gravity",
                     "speed"
                 ]
@@ -6626,7 +6677,17 @@
         "Open": {
             "always": {
                 "allOf": [
-                    "canBreach|Maridia - Pre-Aqueduct",
+                    {
+                        "anyOf": [
+                            "canBreach|Maridia - Pre-Aqueduct",
+                            {
+                                "allOf": [
+                                    "canBreach|Maridia - Portal",
+                                    "SMKeys|Maridia2"
+                                ]
+                            }
+                        ]
+                    },
                     "gravity",
                     {
                         "anyOf": [
@@ -6638,7 +6699,17 @@
             },
             "logical": {
                 "allOf": [
-                    "canReach|Maridia - Pre-Aqueduct",
+                    {
+                        "anyOf": [
+                            "canReach|Maridia - Pre-Aqueduct",
+                            {
+                                "allOf": [
+                                    "canReach|Maridia - Portal",
+                                    "SMKeys|Maridia2"
+                                ]
+                            }
+                        ]
+                    },
                     "gravity",
                     "speed"
                 ]
@@ -6662,6 +6733,7 @@
                             {
                                 "allOf": [
                                     "canBreach|Maridia - Portal",
+                                    "SMKeys|Maridia2",
                                     "super",
                                     "morph",
                                     {
@@ -6747,6 +6819,7 @@
                             {
                                 "allOf": [
                                     "canBreach|Maridia - Portal",
+                                    "SMKeys|Maridia2",
                                     "super",
                                     "morph",
                                     {
@@ -6832,6 +6905,7 @@
                             {
                                 "allOf": [
                                     "canBreach|Maridia - Portal",
+                                    "SMKeys|Maridia2",
                                     "super",
                                     "morph",
                                     {
@@ -6903,6 +6977,7 @@
                             {
                                 "allOf": [
                                     "canBreach|Maridia - Portal",
+                                    "SMKeys|Maridia2",
                                     "super",
                                     "morph",
                                     {
@@ -7330,7 +7405,7 @@
             "always": {
                 "allOf": [
                     "canBreach|Norfair - Business Center",
-                    "super",
+                    "SMKeys|Norfair1|super",
                     "morph",
                     {
                         "anyOf": [
@@ -7356,7 +7431,7 @@
             },
             "logical": {
                 "allOf": [
-                    "super",
+                    "SMKeys|Norfair1|super",
                     "speed",
                     "canPassBombPassages",
                     "varia"
@@ -7369,7 +7444,7 @@
         "Open": {
             "always": {
                 "allOf": [
-                    "super",
+                    "SMKeys|Norfair1|super",
                     {
                         "anyOf": [
                             { // the normal way
@@ -7403,7 +7478,7 @@
             "logical": {
                 "allOf": [
                     "canReach|Norfair - Business Center",
-                    "super",
+                    "SMKeys|Norfair1|super",
                     "speed",
                     "canUsePowerBombs",
                     "varia"
@@ -8409,8 +8484,67 @@
                 ]
             },
             "logical": {
-                "allOf": [
-                    "canReach|Norfair - Crocomire",
+                "allOf": [ // i love copypasting code just to take out one line tammik1Pog
+                    {
+                        "anyOf": [
+                            { // the normal way
+                                "allOf": [
+                                    "canReach|Norfair - Business Center",
+                                    "varia",
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "allOf": [ // croc speedway via ice gates
+                                                    "super",
+                                                    "canUsePowerBombs",
+                                                    "speed"
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [ // frog speedway & croc gate
+                                                    "speed",
+                                                    "wave"
+                                                ]
+                                            },
+                                            {
+                                                "allOf": [
+                                                    "super",
+                                                    "morph",
+                                                    "wave",
+                                                    {
+                                                        "anyOf": [ // precathedral
+                                                            "space",
+                                                            "canIBJ",
+                                                            "hijump",
+                                                            "speed",
+                                                        ]
+                                                    },
+                                                    {
+                                                        "anyOf": [
+                                                            "morphbombs",
+                                                            "powerbomb",
+                                                            "gravity" // remembered highway????!?!!!?!?
+                                                        ]
+                                                    },
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            { // hit LN portal from zelda, go up WRITG, go down mickey mouse, reverse lava dive, go up purple shaft and down croc gate to croc... without morph or speed :)
+                                "allOf": [
+                                    "canReach|Lower Norfair - Portal",
+                                    "varia",
+                                    "gravity",
+                                    "space",
+                                    "screw",
+                                    "super",
+                                    "wave",
+                                ]
+                            }
+                        ]
+                    },
                     {
                         "anyOf": [
                             "grapple",

--- a/data/logic/logic_regions.js
+++ b/data/logic/logic_regions.js
@@ -2018,7 +2018,14 @@
                         "allOf": [
                             "canBreach|Maridia - Pre-Aqueduct",
                             "SMKeys|Maridia2",
-                            "speed",
+                            {
+                                "anyOf": [
+                                    "speed",
+                                    "canMochtroidIceClip",
+                                    "canBombCrystalFlashClip",
+                                    "canSuitlessCrystalFlashClip"
+                                ]
+                            },
                             {
                                 "anyOf": [ // can kill botwoon
                                     "charge",
@@ -2388,7 +2395,24 @@
                     },
                     {
                         "allOf": [
-                            "canBreach|Norfair - Bubble Mountain",
+                            {
+                                "anyOf": [
+                                    "canBreach|Norfair - Bubble Mountain",
+                                    {
+                                        "allOf": [
+                                            "speed",
+                                            "canGateGlitch"
+                                        ]
+                                    },
+                                    {
+                                        "allOf": [
+                                            "speed",
+                                            "wave"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "canUsePowerBombs",
                             "canTraverseGravitron"
                         ]
                     }
@@ -2424,11 +2448,21 @@
                     {
                         "allOf": [
                             "varia",
-                            "canReach|Norfair - Bubble Mountain",
                             "canUsePowerBombs",
                             "space",
                             "gravity",
-                            "super" // sj assured so picky chozo -> 5 super gt fight :)
+                            "super", // sj assured so picky chozo -> 5 super gt fight :)
+                            {
+                                "anyOf": [
+                                    {
+                                        "allOf": [
+                                            "speed",
+                                            "wave"
+                                        ]
+                                    },
+                                    "SMKeys|Norfair2"
+                                ]
+                            }
                         ]
                     }
                 ]


### PR DESCRIPTION
fixes:
- botwoon entry logic not accounting for any sequence breaks
- main street missile not having scout logic
- tracker requiring norfair 2 to get to LN entrance erroneously