### PR TITLE
Make the vertical maps 15px shorter so the caption is visible

### DIFF
--- a/js/track.js
+++ b/js/track.js
@@ -2467,6 +2467,8 @@
 				document.getElementById("map").style.position = "absolute";
 				document.getElementById("map").style.left = "0";
 				document.getElementById("map").style.top = "448";
+				document.getElementById("map_light").style.height = "433";
+				document.getElementById("map_dark").style.height = "433";
 				break;
 		}
 


### PR DESCRIPTION
The caption bar does a nice job of showing the name of the location and what was attached to it but in Vertical mode the caption is hidden behind the dark world map.  I've decreased the height of both maps by 15px each in vertical mode only and now the caption bar is visible.

<img width="447" height="1382" alt="image" src="https://github.com/user-attachments/assets/f6ad7ec5-85a2-4e1e-8935-eca0b8eed16a" />
