### PR TITLE
Add moat clip to magic bat

### DIFF
--- a/data/logic/hmg/logic_nondungeon_checks.js
+++ b/data/logic/hmg/logic_nondungeon_checks.js
@@ -1417,6 +1417,9 @@
             {
               allOf: ["canBreach|Dark World - West", "moonpearl", "mirror", "mitts"],
             },
+            {
+              allOf: ["canBreach|Dark World - East", "moonpearl", "canBootsClip", "mirror"],
+            },
           ],
         },
         logical: {
@@ -1425,6 +1428,9 @@
             "hammer",
             {
               allOf: ["canReach|Dark World - West", "mitts", "moonpearl"],
+            },
+            {
+              allOf: ["canReach|Dark World - East", "moonpearl", "canBootsClip", "mirror"],
             },
           ],
         },
@@ -1998,7 +2004,7 @@
           allOf: ["hammer"],
           anyOf: [
             {
-              allOf: ["canBreach|Dark World - East", "moonpearl", "canBootsClip"],
+              allOf: ["canBreach|Dark World - East", "moonpearl", "canBootsClip" ],
             },
             {
               allOf: ["mitts", "moonpearl"],

--- a/data/logic/owg/logic_nondungeon_checks.js
+++ b/data/logic/owg/logic_nondungeon_checks.js
@@ -1417,6 +1417,9 @@
             {
               allOf: ["canBreach|Dark World - West", "moonpearl", "mirror", "mitts"],
             },
+            {
+              allOf: ["canBreach|Dark World - East", "moonpearl", "canBootsClip", "mirror"],
+            },
           ],
         },
         logical: {
@@ -1425,6 +1428,9 @@
             "hammer",
             {
               allOf: ["canReach|Dark World - West", "mitts", "moonpearl"],
+            },
+            {
+              allOf: ["canReach|Dark World - East", "moonpearl", "canBootsClip", "mirror"],
             },
           ],
         },


### PR DESCRIPTION
See https://imgur.com/a/moat-clips-to-hammerpegs-hype-cave-oyErWnm

The `allOf: ["canBreach|Dark World - East", "moonpearl", "canBootsClip"]` condition is already present in the Peg Cave check, this is just the same thing plus checking for `mirror`.

As mentioned a while ago on Discord, in VT logic there seems to be a (probably erroneous) additional requirement of needing to be able to superspeed but I did not replicate that logic here.